### PR TITLE
Add lutro-pong.lutro release script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+Makefile export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 Makefile export-ignore
+*.moon export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+# Remove some files from being in the .lutro releases
 .gitattributes export-ignore
 .gitignore export-ignore
 Makefile export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+lutro-pong
+lutro-pong.lutro

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 build:
 	@moonc .
 
-run: build
+run:
 	@retroarch -L ~/.config/retroarch/cores/lutro_libretro.so .
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf lutro-pong lutro-pong.lutro
 
 release: clean compile
-	git archive --format=zip --output=${ROOT_DIR}/lutro-pong.lutro master
+	git archive --format=zip --output=${ROOT_DIR}/lutro-pong.lutro release
 
 play-release: release
 	@retroarch -L ~/.config/retroarch/cores/lutro_libretro.so lutro-pong.lutro

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
 compile:
 	@moonc .
 
 retroarch:
-	@retroarch .
+	@retroarch -L ~/.config/retroarch/cores/lutro_libretro.so .
 
 play: compile retroarch
 
 clean:
 	@find . -name "*.lua" -exec rm -rf {} \;
+	rm -rf lutro-pong lutro-pong.lutro
+
+release: clean compile
+	git archive --format=zip --output=${ROOT_DIR}/lutro-pong.lutro master
+
+play-release: release
+	@retroarch -L ~/.config/retroarch/cores/lutro_libretro.so lutro-pong.lutro

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,17 @@
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-compile:
+build:
 	@moonc .
 
-retroarch:
+run: build
 	@retroarch -L ~/.config/retroarch/cores/lutro_libretro.so .
-
-play: compile retroarch
 
 clean:
 	@find . -name "*.lua" -exec rm -rf {} \;
 	rm -rf lutro-pong lutro-pong.lutro
 
-release: clean compile
-	git archive --format=zip --output=${ROOT_DIR}/lutro-pong.lutro release
+release: clean build
+	git archive --format=zip --output=${ROOT_DIR}/lutro-pong.lutro master
 
-play-release: release
+run-release: release
 	@retroarch -L ~/.config/retroarch/cores/lutro_libretro.so lutro-pong.lutro

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Recreation of the 1972 classic video game: [Pong](http://wikipedia.org/wiki/Pong
 2. Build and run using:
 
   ```
-  make run
+  make build run
   ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Lutro Pong
+# [Lutro Pong](http://github.com/libretro/lutro-pong)
 
-Experimental recreation of the 1972 classic video game: [Pong](http://wikipedia.org/wiki/Pong). Built using the [Lutro game framework](http://github.com/libretro/libretro-lutro), for [Libretro/RetroArch](http://libretro.com).
+Recreation of the 1972 classic video game: [Pong](http://wikipedia.org/wiki/Pong). Built using the [Lutro game framework](http://github.com/libretro/libretro-lutro), for [Libretro/RetroArch](http://libretro.com).
 
 ![Screenshot](Resources/screenshot.png)
 
@@ -22,7 +22,7 @@ Experimental recreation of the 1972 classic video game: [Pong](http://wikipedia.
 2. Build and run using:
 
   ```
-  make
+  make run
   ```
 
 


### PR DESCRIPTION
Makes it so that `lutro-pong.lutro` does not include the `.moon` files. Also adds some documentation.
